### PR TITLE
keeping a history of user logins with the paper_trail gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,11 @@ gem 'jquery-rails'
 # TO use devise for authentication
 gem 'devise'
 
+# For login tracking
+gem 'paper_trail', '>= 3.0.0.rc2'
+
+
+
 # To use google charts
 gem 'googlecharts'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,9 @@ GEM
     multi_json (1.8.2)
     mysql2 (0.3.13)
     orm_adapter (0.4.0)
+    paper_trail (3.0.0.rc2)
+      activerecord (>= 3.0, < 5.0)
+      activesupport (>= 3.0, < 5.0)
     polyglot (0.3.3)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
@@ -146,6 +149,7 @@ DEPENDENCIES
   jquery-ui-rails
   kaminari
   mysql2
+  paper_trail (>= 3.0.0.rc2)
   pry
   ptools
   rails (= 3.2.13)

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -12,7 +12,14 @@ class AdminController < ApplicationController
     else
       @admins = Admin.sorted
     end
-	end
+  end
+
+  def logins
+
+    @admin = Admin.find(params[:id])
+    @logins = @admin.versions.map{|version| version.reify}
+
+  end
 
 	def new
 		@admin = Admin.new

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -8,6 +8,7 @@ class Admin < ActiveRecord::Base
   # Setup accessible (or protected) attributes for your model
   attr_accessible :username, :name, :email, :approved, :password, :password_confirmation, :remember_me
 
+  has_paper_trail on: [:update], only: [:current_sign_in_at, :current_sign_in_ip]
 
 	validates :name, :presence => true, :length => { :maximum => 255 }
 	validates :username, :presence => true, :length => { :maximum => 255 }

--- a/app/views/admin/list.html.erb
+++ b/app/views/admin/list.html.erb
@@ -36,6 +36,9 @@
             <%= link_to "Delete", admin_path(admin), method: :delete,
                         confirm: 'Are you sure you want to permanently delete this admin?', class: 'action delete' %>
           </td>
+          <td>
+            <%=  link_to "Logins", logins_admin_path(admin) %>
+          </td>
         </tr>
     <% end %>
   </table>

--- a/app/views/admin/logins.html.erb
+++ b/app/views/admin/logins.html.erb
@@ -1,0 +1,22 @@
+<% @page_title = "#{@admin.name} Login Archive" %>
+<%= link_to("<< Back to Admin Menu", access_path, :class => 'back-link') %>
+<div class="Admin list">
+  <h2><%=  @admin.name %> Logins</h2>
+
+  <div><%= pluralize(@logins.size, 'login') %> logged out of <%= @admin.sign_in_count %> logins total </div>
+  <table class="listing" summary="Campiagn list">
+    <tr class="header">
+      <th>Date</th>
+      <th>IP</th>
+    </tr>
+
+    <% @logins.each do |login| %>
+
+        <tr class="<%= cycle('odd', 'even') %>">
+          <td><%= login.current_sign_in_at %></td>
+          <td><%= login.current_sign_in_ip %></td>
+        </tr>
+    <% end %>
+  </table>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ PhishingFramework::Application.routes.draw do
       put 'update_global_settings'
     end
     member do
+      get 'logins'
       post 'approve'
       post 'revoke'
       delete 'destroy'

--- a/db/migrate/20131204204849_create_versions.rb
+++ b/db/migrate/20131204204849_create_versions.rb
@@ -1,0 +1,18 @@
+class CreateVersions < ActiveRecord::Migration
+  def self.up
+    create_table :versions do |t|
+      t.string   :item_type, :null => false
+      t.integer  :item_id,   :null => false
+      t.string   :event,     :null => false
+      t.string   :whodunnit
+      t.text     :object
+      t.datetime :created_at
+    end
+    add_index :versions, [:item_type, :item_id]
+  end
+
+  def self.down
+    remove_index :versions, [:item_type, :item_id]
+    drop_table :versions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20131115212342) do
+ActiveRecord::Schema.define(:version => 20131204204849) do
 
   create_table "admins", :force => true do |t|
     t.string   "name"
@@ -134,6 +134,17 @@ ActiveRecord::Schema.define(:version => 20131115212342) do
   end
 
   add_index "templates", ["campaign_id"], :name => "index_templates_on_campaign_id"
+
+  create_table "versions", :force => true do |t|
+    t.string   "item_type",  :null => false
+    t.integer  "item_id",    :null => false
+    t.string   "event",      :null => false
+    t.string   "whodunnit"
+    t.text     "object"
+    t.datetime "created_at"
+  end
+
+  add_index "versions", ["item_type", "item_id"], :name => "index_versions_on_item_type_and_item_id"
 
   create_table "victims", :force => true do |t|
     t.string   "email_address"


### PR DESCRIPTION
This uses paper_trail (https://github.com/airblade/paper_trail) to keep track of the times and ip addresses of all successful login attempts.

The there is a link in the admin list to the login archive.

Requires a database migration.

Addresses enhancement issue #46
