### PR TITLE
Simple typo fix - [Ss]ucess > [Ss]uccess

### DIFF
--- a/app/views/reports/stats.html.erb
+++ b/app/views/reports/stats.html.erb
@@ -33,8 +33,8 @@
       <h2 id='clicked' class='textItems' style="color:black;">-</h2>
     </div>
     <div class='colorBox' style="width:192.5px;height:100px;top:550px;left:607.5px;background-color: #9edae5">
-      <h3 class='textItems' style="color:grey;">Sucess Rate: </h2>
-      <h2 id='sucess_rate' class='textItems' style="color:black;">-</h2>
+      <h3 class='textItems' style="color:grey;">Success Rate: </h2>
+      <h2 id='success_rate' class='textItems' style="color:black;">-</h2>
     </div>
     <svg id="barChart" class='colorBox' style="width:395px;height:210px;top:440px;left:0px;background-color: #FFF;">
     </svg>
@@ -271,7 +271,7 @@ $(document).ready(function() {
       $("#sent").text(sum.sent)
       $("#clicked").text(sum.clicked)
       $("#opened").text(sum.opened)   
-      $("#sucess_rate").text(Math.floor((sum.clicked/sum.sent)*100) + "%")
+      $("#success_rate").text(Math.floor((sum.clicked/sum.sent)*100) + "%")
     
       data = [
         {"label":"Clicked", "value":sum.clicked},


### PR DESCRIPTION
Simple type fix - changed "Sucess" to "Success" in stats view.

Before
![before](https://cloud.githubusercontent.com/assets/3915057/4319055/c23d1a5e-3f26-11e4-96c9-5e0a712b5085.png)

After
![after](https://cloud.githubusercontent.com/assets/3915057/4319056/c76a53c0-3f26-11e4-8736-f99030f704a6.png)
