### PR TITLE
Modify email_controller.rb to check victims for sent flag

### DIFF
--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -58,7 +58,7 @@ class EmailController < ApplicationController
     @campaign = Campaign.find(params[:id])
     @campaign.update_attributes(active: true)
     @blast = @campaign.blasts.create(test: false)
-    victims = Victim.where("campaign_id = ? and archive = ?", params[:id], false)
+    victims = Victim.where("campaign_id = ? and archive = ? and sent = ?", params[:id], false, false)
     if GlobalSettings.asynchronous?
       begin
         victims.each do |target|


### PR DESCRIPTION
If sent flag set to true, exclude from victims list to prevent duplicate emails from being sent if a second launch is initiated.
