### PR TITLE
fix errors from apache restarts

### DIFF
--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -291,7 +291,7 @@ class Campaign < ActiveRecord::Base
 
   def reload_apache
     restart_apache = GlobalSettings.first.command_apache_restart
-    system("#{restart_apache} > /dev/null")
+    Process.spawn("#{restart_apache} > /dev/null")
   end
 
 end


### PR DESCRIPTION
This change should resolve (at least it did that for me) the errors that can arise with the apache reload/restart after activating/deactivating a campaign.