### PR TITLE
Dont return SMTP password

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -46,6 +46,9 @@ class CampaignsController < ApplicationController
 
 	def update
 		@campaign = Campaign.find(params[:id])
+		if params[:campaign][:email_settings_attributes][:smtp_password].blank? && !@campaign.email_settings.smtp_password.blank?
+			params[:campaign][:email_settings_attributes][:smtp_password] = @campaign.email_settings.smtp_password
+		end
 		if @campaign.update_attributes(params[:campaign])
 			redirect_to @campaign, notice: "Campaign Updated"
 		else

--- a/app/views/campaigns/_smtp_settings.html.erb
+++ b/app/views/campaigns/_smtp_settings.html.erb
@@ -107,7 +107,6 @@
           <div class="col-xs-8">
             <%= ff.password_field(:smtp_password,
                   placeholder: 'password',
-                  value: @campaign.email_settings.smtp_password,
                   class: 'form-control') %>
           </div>
         </div>


### PR DESCRIPTION
Campaign pages returns the SMTP password in cleartext in the form. 