### PR TITLE
Redis warnings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,12 +28,12 @@ protected
       q = Sidekiq::Stats.new.enqueued
       @redis = true
       if q > 0 and !@sidekiq
-        flash[:warning] = "You have #{ActionController::Base.helpers.pluralize(q, 'job')} enqueued, but sidekiq is not running"
+        flash[:warning] = "You have #{ActionController::Base.helpers.pluralize(q, 'job')} enqueued, but Sidekiq is not running"
       end
     rescue Redis::CannotConnectError => e
-      flash[:warning] = e.message
       logger.error e.message
       @redis = false
+      flash[:warning] = e.message if e.message =~ /timeout/i
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   include PublicActivity::StoreController
 
   protect_from_forgery
-  
+
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_filter :authenticate_admin!
   before_filter :system_status
@@ -31,6 +31,8 @@ protected
         flash[:warning] = "You have #{ActionController::Base.helpers.pluralize(q, 'job')} enqueued, but sidekiq is not running"
       end
     rescue Redis::CannotConnectError => e
+      flash[:warning] = e.message
+      logger.error e.message
       @redis = false
     end
   end

--- a/app/models/system_monitor.rb
+++ b/app/models/system_monitor.rb
@@ -29,7 +29,8 @@ class SystemMonitor
       pid = File.read(pid_file)
       Process.getpgid(pid.to_i)
     rescue Exception => e
-      Rails.logger.error e
+      Rails.logger.error %Q(Sidekiq is not running, or pid file, '#{pid_file}' is invalid:
+      #{e.class} - #{e.message})
       false
     end
   end


### PR DESCRIPTION
The Redis timeout is very innocuous to debug. 

If the Redis server isn't running, we just get a Connection Refused, which is fast.

If the Redis server is unreachable (e.g. remote server, firewalled etc), we get a 10 seconds timeout. As the connection is attempted in application_controller it happens on all pages :(

Check it for yourself by doing:

`sudo iptables -I INPUT -p tcp --dport 6379 -j DROP`


This adds a flash warning if the Redis server is timing out. Additionally it adds more verbose logging for both Sidekiq and Redis connections:

![image](https://cloud.githubusercontent.com/assets/1854557/8759666/9853c440-2cf1-11e5-984f-04e07058af99.png)


```
Sidekiq is not running, or pid file, '/home/ben/git/phishing-frenzy/tmp/pids/sidekiq.pid' is invalid:
      Errno::ESRCH - No such process
Error connecting to Redis on 127.0.0.1:6379 (Redis::TimeoutError)
```

