### PR TITLE
Correct BeEF system status

### DIFF
--- a/app/models/system_monitor.rb
+++ b/app/models/system_monitor.rb
@@ -19,7 +19,7 @@ class SystemMonitor
 
   # determine if BeeF is running
   def self.beef
-    beef_output = `ps aux | grep beef | grep -v color`
+    beef_output = `ps aux | grep '[b]eef'`
     beef_output =~ /beef/
   end
 

--- a/app/views/layouts/_system_status.html.erb
+++ b/app/views/layouts/_system_status.html.erb
@@ -31,7 +31,7 @@
       <% end %>
       <% if @beef %>
           <li><%= link_to("#{PhishingFramework::SITE_URL}:3000/ui/panel", target: "_blank") do %>
-                <span class="label label-success">BeeF</span>
+                <span class="label label-success">BeEF</span>
             <% end %></li>
       <% else %>
           <li><%= link_to("#") do %>


### PR DESCRIPTION
I was getting erroneous Green status for BeEF despite not being installed:

`ben       6426  0.0  0.0  13584   920 pts/1    S+   01:58   0:00 grep beef` 

Used a smarter grep command to prevent matching `grep`!