### PR TITLE
Fix Cmd Exec Vulns

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -57,16 +57,16 @@ class AdminController < ApplicationController
 	end
 
 	def global_settings
-		@global_settings = GlobalSettings.first
+		@global_settings = GlobalSettings.instance
 	end
 
 	def update_global_settings
-		@global_settings = GlobalSettings.first
+		@global_settings = GlobalSettings.instance
 		if @global_settings.update_attributes(params[:global_settings])
 			flash[:notice] = "Settings Updated"
 			redirect_to(:action => 'global_settings')
 		else
-			render('global_settings')		
+			render('global_settings')
 		end
 	end
 

--- a/app/controllers/tools_controller.rb
+++ b/app/controllers/tools_controller.rb
@@ -5,7 +5,7 @@ class ToolsController < ApplicationController
 
   def emails
     # warn user if bing api key is not configured
-    if GlobalSettings.first.bing_api.to_s.empty?
+    if GlobalSettings.instance.bing_api.to_s.empty?
       flash.now[:warning] = "Bing API Key Required for Email Enumeration"
     end
 
@@ -41,7 +41,7 @@ class ToolsController < ApplicationController
 
   def enumerate_emails
     # ensure bing api key is entered
-    bing_api = GlobalSettings.first.bing_api
+    bing_api = GlobalSettings.instance.bing_api
     if bing_api.to_s.empty?
       redirect_to tools_emails_path, notice: "Unable to perform Operation without Bing API Key"
       return

--- a/app/helpers/apache_helper.rb
+++ b/app/helpers/apache_helper.rb
@@ -1,0 +1,67 @@
+module ApacheHelper
+
+  def self.running?
+    `#{PhishingFramework::APACHE_STATUS_COMMAND} 2>&1` =~ /pid/
+  end
+
+  def self.vhosts
+    vhosts_output = `#{PhishingFramework::APACHE_VHOSTS_COMMAND} 2>&1`
+    if vhosts_output.blank?
+      []
+    else
+      vhosts_output.split(/\r?\n/)[3..20]
+    end
+  end
+
+  def self.config_path
+    PhishingFramework::APACHE_CONFIG_PATH
+  end
+
+  def self.sites_enabled_path
+    File.join(PhishingFramework::APACHE_CONFIG_PATH, 'sites-enabled')
+  end
+
+  def self.sites_available_path
+    File.join(PhishingFramework::APACHE_CONFIG_PATH, 'sites-available')
+  end
+
+  def self.vhost_file_path(id)
+    File.join(sites_available_path, "#{id}.conf")
+  end
+
+  def self.sites_path_writable
+    # ensure we have write access to sites-*
+    errors = []
+    unless File.writable?(sites_available_path)
+      access = false
+      errors << [:apache, "File Permission Issue: chmod -R 755 and chown www-data:www-data #{sites_available_path}"]
+    end
+
+    unless File.writable?(sites_enabled_path)
+      access = false
+      errors << [:apache, "File Permission Issue: chmod -R 755 and chown www-data:www-data #{sites_enabled_path}"]
+    end
+
+    errors
+  end
+
+  def self.log(message)
+    Rails.logger.info "APACHE: #{message}"
+  end
+
+  def self.enable_site(id)
+    log `a2ensite #{id}.conf 2&>1`
+  end
+
+  def self.disable_site(id)
+    log `a2dissite #{id}.conf 2&>1`
+  end
+
+  def self.reload
+    log `#{PhishingFramework::APACHE_RESTART_COMMAND} 2&>1`
+  end
+
+  def self.rm_vhost_file(id)
+    FileUtils.rm_rf vhost_file_path(id) if File.exists?(vhost_file_path(id))
+  end
+end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -183,8 +183,8 @@ class Campaign < ActiveRecord::Base
       errors.add(:fqdn, "cannot be nil when making campaign active") unless campaign_settings.fqdn.present?
 
       # ensure we have write access to sites-enabled   
-      unless File.writable?(GlobalSettings.first.sites_enabled_path)
-        errors.add(:apache, "File Permission Issue: chmod -R 755 and chown www-data:www-data #{GlobalSettings.first.sites_enabled_path}")
+      unless File.writable?(GlobalSettings.instance.sites_enabled_path)
+        errors.add(:apache, "File Permission Issue: chmod -R 755 and chown www-data:www-data #{GlobalSettings.instance.sites_enabled_path}")
       end
     end
 
@@ -260,7 +260,7 @@ class Campaign < ActiveRecord::Base
 
   def select_beef_url
     return campaign_settings.beef_url unless campaign_settings.beef_url.empty?
-    return GlobalSettings.first.beef_url unless GlobalSettings.first.beef_url.empty?
+    return GlobalSettings.instance.beef_url unless GlobalSettings.instance.beef_url.empty?
     return "#{PhishingFramework::SITE_URL}:3000/hook.js"
   end
 
@@ -269,7 +269,7 @@ class Campaign < ActiveRecord::Base
   end
 
   def vhost_file
-    "#{GlobalSettings.first.sites_enabled_path}/#{self.id}.conf"
+    "#{GlobalSettings.instance.sites_enabled_path}/#{self.id}.conf"
   end
 
   def inflatable?(file)
@@ -294,7 +294,7 @@ class Campaign < ActiveRecord::Base
   end
 
   def reload_apache
-    restart_apache = GlobalSettings.first.command_apache_restart
+    restart_apache = GlobalSettings.instance.command_apache_restart
     Process.spawn("#{restart_apache} > /dev/null")
   end
 

--- a/app/models/global_settings.rb
+++ b/app/models/global_settings.rb
@@ -1,23 +1,34 @@
 class GlobalSettings < ActiveRecord::Base
 
-  attr_accessible :command_apache_restart, :command_apache_vhosts, :command_apache_status, :sites_enabled_path, :smtp_timeout, :asynchronous, :bing_api, :beef_url, :reports_refresh
+  attr_accessible :smtp_timeout, :asynchronous, :bing_api, :beef_url, :reports_refresh, :singleton
 
-  validates :command_apache_restart, :presence => true, :length => {:maximum => 255}
-  validates :command_apache_vhosts, :presence => true, :length => {:maximum => 255}
-  validates :sites_enabled_path, :presence => true, :length => {:maximum => 255}
   validates :smtp_timeout, :presence => true, :length => {:maximum => 2},
             :numericality => {:greater_than_or_equal_to => 1, :less_than_or_equal_to => 20}
+
+  validates_inclusion_of :singleton, in: [0]
+
+  def self.instance
+    begin
+      find(1)
+    rescue ActiveRecord::RecordNotFound
+      row = GlobalSettings.new
+      row.singleton = 0
+      row.save!
+      row
+    end
+  end
 
   def self.asynchronous?
     first.asynchronous?
   end
 
   def self.apache_status
-    `#{first.command_apache_status} 2>&1`
+    #`#{PhishingFrenzy::APACHE_STATUS_COMMAND} 2>&1`
   end
 
   def self.apache_vhosts
-    vhosts_output = `#{first.command_apache_vhosts} 2>&1`
+    vhosts_output = ""
+    #vhosts_output = `#{PhishingFrenzy::APACHE_VHOSTS_COMMAND} 2>&1`
     if vhosts_output.blank?
       []
     else

--- a/app/models/global_settings.rb
+++ b/app/models/global_settings.rb
@@ -19,20 +19,6 @@ class GlobalSettings < ActiveRecord::Base
   end
 
   def self.asynchronous?
-    first.asynchronous?
-  end
-
-  def self.apache_status
-    #`#{PhishingFrenzy::APACHE_STATUS_COMMAND} 2>&1`
-  end
-
-  def self.apache_vhosts
-    vhosts_output = ""
-    #vhosts_output = `#{PhishingFrenzy::APACHE_VHOSTS_COMMAND} 2>&1`
-    if vhosts_output.blank?
-      []
-    else
-      vhosts_output.split("\n")[3..20]
-    end
+    instance.asynchronous?
   end
 end

--- a/app/models/system_monitor.rb
+++ b/app/models/system_monitor.rb
@@ -2,13 +2,12 @@ class SystemMonitor
 
   # determine if apache is running
   def self.apache
-    apache_output = GlobalSettings.apache_status
-    apache_output =~ /pid/
+    ApacheHelper.running?
   end
 
-  # determine if any VHOST are configured
+  # retrieve configured vhosts
   def self.vhosts
-    GlobalSettings.apache_vhosts
+    ApacheHelper.vhosts
   end
 
   # determine if metasploit is running

--- a/app/models/system_monitor.rb
+++ b/app/models/system_monitor.rb
@@ -1,13 +1,15 @@
+require 'apache_controller'
+
 class SystemMonitor
 
   # determine if apache is running
   def self.apache
-    ApacheHelper.running?
+    ApacheController.running?
   end
 
   # retrieve configured vhosts
   def self.vhosts
-    ApacheHelper.vhosts
+    ApacheController.vhosts
   end
 
   # determine if metasploit is running

--- a/app/views/admin/global_settings.html.erb
+++ b/app/views/admin/global_settings.html.erb
@@ -10,27 +10,6 @@
 
   <table class="table borderless" summary="Global Settings fields">
     <tr>
-      <th>Apache Restart Command</th>
-      <td><span class="ui-icon ui-icon-help" title='Command used on the Operating System to restart Apache. This is required to manage the virtual hosts for phishing websites'></span></td>
-      <td><%= f.text_field(:command_apache_restart, class: 'form-control') %></td>
-    </tr>
-    <tr>
-      <th>Apache Status Command</th>
-      <td><span class="ui-icon ui-icon-help" title='Command used on the Operating System to status Apache. This is required for monitoring the web server.'></span></td>
-      <td><%= f.text_field(:command_apache_status, class: 'form-control') %></td>
-    </tr>
-    <tr>
-      <th>Apache VHOST Command</th>
-      <td><span class="ui-icon ui-icon-help" title='Command used on the Operating System for listing all Virtual Hosts.'></span></td>
-      <td><%= f.text_field(:command_apache_vhosts, class: 'form-control') %></td>
-    </tr>
-    <tr>
-      <th>Apache sites-enabled Path</th>
-      <td>
-        <span class="ui-icon ui-icon-help" title='Path or location of where the Apache stores the sites-enabled virtual hosts'></span></td>
-      <td><%= f.text_field(:sites_enabled_path, class: 'form-control') %></td>
-    </tr>
-    <tr>
       <th>Reports Refresh Time</th>
       <td><span class="ui-icon ui-icon-help" title='Time in seconds use to poll the server for stats on the campaign stats page'></span></td>
       <td><%= f.text_field(:reports_refresh, class: 'form-control') %></td>

--- a/app/views/campaigns/_phishing_options.html.erb
+++ b/app/views/campaigns/_phishing_options.html.erb
@@ -53,7 +53,7 @@
         <span class="glyphicon glyphicon-question-sign" title='Hook Browsers when targets land on your phishing website. Each php website file will be taged with the javascript required to hook target browsers. Must be running beef service to hook properly'></span>
       </div>
       <div class="col-xs-8">
-        <%= ff.text_field(:beef_url, value: GlobalSettings.first.beef_url, class: 'form-control') %></td>
+        <%= ff.text_field(:beef_url, value: GlobalSettings.instance.beef_url, class: 'form-control') %></td>
       </div>
     </div>
 

--- a/app/views/reports/stats.html.erb
+++ b/app/views/reports/stats.html.erb
@@ -281,7 +281,7 @@ $(document).ready(function() {
     });
 
 
-  }, <%= (GlobalSettings.first.reports_refresh.to_f * 1000.0).to_i %>);
+  }, <%= (GlobalSettings.instance.reports_refresh.to_f * 1000.0).to_i %>);
 });
 
 /*

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,11 @@ module PhishingFramework
   # Default website for reports stuff, must change to callback.
   SITE_URL = "http://phishingfrenzy.local"
 
+  # Move to an config/apache.rb?
+  APACHE_STATUS_COMMAND = '/etc/init.d/apache2 status'
+  APACHE_RESTART_COMMAND = 'sudo /etc/init.d/apache2 reload'
+  APACHE_VHOSTS_COMMAND = 'apache2ctl -S'
+  APACHE_CONFIG_PATH = '/etc/apache2/'
 
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
@@ -16,7 +21,7 @@ module PhishingFramework
 
     # Custom directories with classes and modules you want to be autoloadable.
     # config.autoload_paths += %W(#{config.root}/extras)
-    
+
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,12 +8,6 @@ module PhishingFramework
   # Default website for reports stuff, must change to callback.
   SITE_URL = "http://phishingfrenzy.local"
 
-  # Move to an config/apache.rb?
-  APACHE_STATUS_COMMAND = '/etc/init.d/apache2 status'
-  APACHE_RESTART_COMMAND = 'sudo /etc/init.d/apache2 reload'
-  APACHE_VHOSTS_COMMAND = 'apache2ctl -S'
-  APACHE_CONFIG_PATH = '/etc/apache2/'
-
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/initializers/apache.rb
+++ b/config/initializers/apache.rb
@@ -1,0 +1,16 @@
+require 'apache_controller'
+
+def silence_warnings(&block)
+    warn_level = $VERBOSE
+    $VERBOSE = nil
+    result = block.call
+    $VERBOSE = warn_level
+    result
+end
+
+silence_warnings do
+  ApacheController::APACHE_STATUS_COMMAND = '/etc/init.d/apache2 status'
+  ApacheController::APACHE_RESTART_COMMAND = 'sudo /etc/init.d/apache2 reload'
+  ApacheController::APACHE_VHOSTS_COMMAND = 'apache2ctl -S'
+  ApacheController::APACHE_CONFIG_PATH = '/etc/apache2/'
+end

--- a/db/migrate/20150718094845_add_singleton_to_global_settings.rb
+++ b/db/migrate/20150718094845_add_singleton_to_global_settings.rb
@@ -1,0 +1,6 @@
+class AddSingletonToGlobalSettings < ActiveRecord::Migration
+  def change
+    add_column :global_settings, :singleton, :integer
+    add_index :global_settings, :singleton, unique: true
+  end
+end

--- a/db/migrate/20150718095758_remove_commands_from_global_settings.rb
+++ b/db/migrate/20150718095758_remove_commands_from_global_settings.rb
@@ -1,0 +1,8 @@
+class RemoveCommandsFromGlobalSettings < ActiveRecord::Migration
+  def change
+    remove_column :global_settings, :command_apache_status
+    remove_column :global_settings, :command_apache_restart
+    remove_column :global_settings, :command_apache_vhosts
+    remove_column :global_settings, :sites_enabled_path
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150714194319) do
+ActiveRecord::Schema.define(version: 20150718094845) do
 
   create_table "activities", force: true do |t|
     t.integer  "trackable_id"
@@ -75,7 +75,10 @@ ActiveRecord::Schema.define(version: 20150714194319) do
     t.integer  "blast_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "message_id"
   end
+
+  add_index "baits", ["message_id"], name: "index_baits_on_message_id", using: :btree
 
   create_table "blasts", force: true do |t|
     t.integer  "campaign_id"
@@ -182,7 +185,10 @@ ActiveRecord::Schema.define(version: 20150714194319) do
     t.string   "beef_url"
     t.string   "sites_enabled_path",     default: "/etc/apache2/sites-enabled"
     t.integer  "reports_refresh",        default: 15
+    t.integer  "singleton"
   end
+
+  add_index "global_settings", ["singleton"], name: "index_global_settings_on_singleton", unique: true, using: :btree
 
   create_table "harvested_emails", force: true do |t|
     t.string   "email"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150718094845) do
+ActiveRecord::Schema.define(version: 20150718095758) do
 
   create_table "activities", force: true do |t|
     t.integer  "trackable_id"
@@ -174,17 +174,13 @@ ActiveRecord::Schema.define(version: 20150718094845) do
   add_index "email_settings", ["campaign_id"], name: "index_email_settings_on_campaign_id", using: :btree
 
   create_table "global_settings", force: true do |t|
-    t.string   "command_apache_restart"
-    t.integer  "smtp_timeout",           default: 5
+    t.integer  "smtp_timeout",    default: 5
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "command_apache_status"
-    t.string   "command_apache_vhosts",  default: "apache2ctl -S"
-    t.boolean  "asynchronous",           default: false
+    t.boolean  "asynchronous",    default: false
     t.string   "bing_api"
     t.string   "beef_url"
-    t.string   "sites_enabled_path",     default: "/etc/apache2/sites-enabled"
-    t.integer  "reports_refresh",        default: 15
+    t.integer  "reports_refresh", default: 15
     t.integer  "singleton"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,14 +1,6 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 
-# create global settings if it does not exist
-if GlobalSettings.count == 0
-	GlobalSettings.create(
-		command_apache_restart: 'sudo /etc/init.d/apache2 reload',
-		command_apache_status: '/etc/init.d/apache2 status'
-	)
-end
-
 # create admin account with default password if it does not exist
 admin = Admin.find_by(username: "admin")
 unless admin.present?

--- a/lib/apache_controller.rb
+++ b/lib/apache_controller.rb
@@ -1,11 +1,15 @@
-module ApacheHelper
+module ApacheController
+  APACHE_STATUS_COMMAND = '/etc/init.d/apache2 status'
+  APACHE_RESTART_COMMAND = 'sudo /etc/init.d/apache2 reload'
+  APACHE_VHOSTS_COMMAND = 'apache2ctl -S'
+  APACHE_CONFIG_PATH = '/etc/apache2/'
 
   def self.running?
-    `#{PhishingFramework::APACHE_STATUS_COMMAND} 2>&1` =~ /pid/
+    !!(`#{APACHE_STATUS_COMMAND} 2>&1` =~ /pid/)
   end
 
   def self.vhosts
-    vhosts_output = `#{PhishingFramework::APACHE_VHOSTS_COMMAND} 2>&1`
+    vhosts_output = `#{APACHE_VHOSTS_COMMAND} 2>&1`
     if vhosts_output.blank?
       []
     else
@@ -14,15 +18,15 @@ module ApacheHelper
   end
 
   def self.config_path
-    PhishingFramework::APACHE_CONFIG_PATH
+    APACHE_CONFIG_PATH
   end
 
   def self.sites_enabled_path
-    File.join(PhishingFramework::APACHE_CONFIG_PATH, 'sites-enabled')
+    File.join(APACHE_CONFIG_PATH, 'sites-enabled')
   end
 
   def self.sites_available_path
-    File.join(PhishingFramework::APACHE_CONFIG_PATH, 'sites-available')
+    File.join(APACHE_CONFIG_PATH, 'sites-available')
   end
 
   def self.vhost_file_path(id)
@@ -58,7 +62,7 @@ module ApacheHelper
   end
 
   def self.reload
-    log `#{PhishingFramework::APACHE_RESTART_COMMAND} 2&>1`
+    log `#{APACHE_RESTART_COMMAND} 2&>1`
   end
 
   def self.rm_vhost_file(id)


### PR DESCRIPTION
This prevents the abuse of command exec vulns in the Apache commands. These values should be relatively static (even across environments) so there isn't really a good reason to have them dynamically configurable. 

Configuration of Apache commands/paths now takes place in config/initializers/apache.rb

* GlobalSettings is now a Singleton and forced to be so in the database due to a uniqueness check.
* An ApacheController library class has been added which takes away some of the control burden from Campaign. This could probably go further to simplify the Campaign logic.
* Have moved to follow the Apache standard of writing to sites-available and creating a symlink when the site is activated. 