### PR TITLE
Use SMTP Domain for message ID

### DIFF
--- a/app/mailers/phishing_frenzy_mailer.rb
+++ b/app/mailers/phishing_frenzy_mailer.rb
@@ -10,7 +10,7 @@ class PhishingFrenzyMailer < ActionMailer::Base
     phishing_url = @campaign.email_settings.phishing_url
     blast = @campaign.blasts.find(blast_id)
 
-    # We use our a custom message and content ID to prevent leaking data
+    # We use a custom message and content ID to prevent leaking data
     # about our phishing setup
     mid = cid = "<#{Mail.random_tag}@#{@campaign.email_settings.domain}>"
 

--- a/app/mailers/phishing_frenzy_mailer.rb
+++ b/app/mailers/phishing_frenzy_mailer.rb
@@ -12,12 +12,13 @@ class PhishingFrenzyMailer < ActionMailer::Base
 
     # We use a custom message and content ID to prevent leaking data
     # about our phishing setup
-    mid = cid = "<#{Mail.random_tag}@#{@campaign.email_settings.domain}>"
+    mid = "<#{Mail.random_tag}@#{@campaign.email_settings.domain}>"
 
     @campaign.template.images.each do |image|
       attachments.inline[image[:file]] = File.read(image.file.current_path)
       # Only inline attachments have cids:
       # https://github.com/mikel/mail/blob/master/lib/mail/part.rb#L42
+      cid = "<#{Mail.random_tag}@#{@campaign.email_settings.domain}>"
       attachments[image[:file]].add_content_id(cid)
     end
 

--- a/app/mailers/phishing_frenzy_mailer.rb
+++ b/app/mailers/phishing_frenzy_mailer.rb
@@ -34,6 +34,7 @@ class PhishingFrenzyMailer < ActionMailer::Base
     end
 
     mail_opts =  {
+        message_id: "<#{Mail.random_tag}@#{@campaign.email_settings.domain}>",
         to: victim.email_address,
         from: "\ #{@campaign.email_settings.display_from}\ \<#{@campaign.email_settings.from}\>",
         subject: @campaign.email_settings.subject,

--- a/app/mailers/phishing_frenzy_mailer.rb
+++ b/app/mailers/phishing_frenzy_mailer.rb
@@ -12,7 +12,7 @@ class PhishingFrenzyMailer < ActionMailer::Base
 
     # We use a custom message and content ID to prevent leaking data
     # about our phishing setup
-    mid = "<#{Mail.random_tag}@#{@campaign.email_settings.domain}>"
+    mid = "<#{Mail.random_tag}@#{@campaign.email_settings.domain}.mail>"
 
     @campaign.template.images.each do |image|
       attachments.inline[image[:file]] = File.read(image.file.current_path)

--- a/app/mailers/phishing_frenzy_mailer.rb
+++ b/app/mailers/phishing_frenzy_mailer.rb
@@ -10,8 +10,15 @@ class PhishingFrenzyMailer < ActionMailer::Base
     phishing_url = @campaign.email_settings.phishing_url
     blast = @campaign.blasts.find(blast_id)
 
+    # We use our a custom message and content ID to prevent leaking data
+    # about our phishing setup
+    mid = cid = "<#{Mail.random_tag}@#{@campaign.email_settings.domain}>"
+
     @campaign.template.images.each do |image|
       attachments.inline[image[:file]] = File.read(image.file.current_path)
+      # Only inline attachments have cids:
+      # https://github.com/mikel/mail/blob/master/lib/mail/part.rb#L42
+      attachments[image[:file]].add_content_id(cid)
     end
 
     @campaign.template.file_attachments.each do |attachment|
@@ -34,7 +41,7 @@ class PhishingFrenzyMailer < ActionMailer::Base
     end
 
     mail_opts =  {
-        message_id: "<#{Mail.random_tag}@#{@campaign.email_settings.domain}>",
+        message_id: mid,
         to: victim.email_address,
         from: "\ #{@campaign.email_settings.display_from}\ \<#{@campaign.email_settings.from}\>",
         subject: @campaign.email_settings.subject,
@@ -98,11 +105,12 @@ class PhishingFrenzyMailer < ActionMailer::Base
 
   def campaign_anonymous_smtp_settings
     {
-      :openssl_verify_mode => @campaign.email_settings.openssl_verify_mode_class,
+      openssl_verify_mode: @campaign.email_settings.openssl_verify_mode_class,
       address: @campaign.email_settings.smtp_server_out,
       port: @campaign.email_settings.smtp_port,
       enable_starttls_auto: @campaign.email_settings.enable_starttls_auto,
-      return_response: true
+      return_response: true,
+      domain: @campaign.email_settings.domain
     }
   end
 


### PR DESCRIPTION
Fixes #209 
### Before

```
sudo python -m smtpd -n -c DebuggingServer localhost:1025 |grep ben-dev
Message-ID: <55ad48f784f7b_134c3ad561c1016c8@ben-dev.mail>
  <img src="cid:55ad4e86132d5_134c3ad561c103015@ben-dev.mail" />
Content-ID: <55ad4e86132d5_134c3ad561c103015@ben-dev.mail>
```
### After

```
Message-ID: <55ad5597a5502_134c3fc7b60bc814107264@test.com>
  <img src="cid:55ad5597a5502_134c3fc7b60bc814107264@test.com" />
Content-ID: <55ad5597a5502_134c3fc7b60bc814107264@test.com>
```
## Verify
- [ ] Inline images still display correctly!
