### PR TITLE
Update the PHP Code

### DIFF
--- a/app/views/reports/tags.txt.erb
+++ b/app/views/reports/tags.txt.erb
@@ -2,6 +2,30 @@
 // Turn off all error reporting
 error_reporting(0);
 
+if (isset($_GET['uid'])) {
+  $uid = $_GET['uid'];
+  } else {
+    header('404 Not Found', true, 404);
+    echo "404 Page Not Found";
+    exit();
+  }
+
+function get_ip() {
+    if (function_exists('apache_request_headers')) {
+      $headers = apache_request_headers();
+    } else {
+      $headers = $_SERVER;
+    }
+    if (array_key_exists('X-Forwarded-For',$headers) && filter_var($headers['X-Forwarded-For'],FILTER_VALIDATE_IP,FILTER_FLAG_IPV4)) {
+      $the_ip = $headers['X-Forwarded-For'];
+    } elseif (array_key_exists('HTTP_X_FORWARDED_FOR',$headers) && filter_var($headers['HTTP_X_FORWARDED_FOR'],FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+      $the_ip = $headers['HTTP_X_FORWARDED_FOR'];
+    } else {
+      $the_ip = filter_var($_SERVER['REMOTE_ADDR'],FILTER_VALIDATE_IP,FILTER_FLAG_IPV4);
+    }
+    return $the_ip;
+  }
+
 $password = $_POST['PasswordForm'];
 $username = $_POST['UsernameForm'];
 
@@ -9,8 +33,7 @@ if ($password != '') {
   $creds = 'user:' . $username . ' password:' . $password;
 }
 
-$uid = $_GET['uid'];
-$ip = $_SERVER['REMOTE_ADDR'];
+$ip = get_ip();
 $browser = $_SERVER['HTTP_USER_AGENT'];
 $host = $_SERVER['HTTP_HOST'];
 $url = "<%= GlobalSettings.first.site_url %>" . '/reports/results/';


### PR DESCRIPTION
Give a 404 error if no UID is supplied. This prevents random crawlers potentially getting exploited. Also makes it slightly harder for incident response. We should probably log these as Visits in some fashion so we can identify people trying to probe the website. Additionally in future maybe we should check if the UID is actually valid, and maybe reject the visit if its a duplicate?

Also detect if X-Forwarded-For is used (e.g. from a reverse web proxy), and use that as the external IP. This can potentially be spoofed but who would?

Fixes #207 
Fixes #200 

