### PR TITLE
Fix Email Generation

### DIFF
--- a/app/mailers/phishing_frenzy_mailer.rb
+++ b/app/mailers/phishing_frenzy_mailer.rb
@@ -21,8 +21,8 @@ class PhishingFrenzyMailer < ActionMailer::Base
       }
     end
 
-    victim = get_victim(target_email, campaign_id)
-    uid = victim.uid.to_s
+    @target = get_victim(target_email, campaign_id)
+    uid = @target.uid.to_s
 
     if @campaign.campaign_settings.track_uniq_visitors?
       @url = "#{phishing_url}?uid=#{uid}"
@@ -34,7 +34,7 @@ class PhishingFrenzyMailer < ActionMailer::Base
     end
 
     mail_opts =  {
-        to: victim.email_address,
+        to: @target.email_address,
         from: "\ #{@campaign.email_settings.display_from}\ \<#{@campaign.email_settings.from}\>",
         subject: @campaign.email_settings.subject,
         template_path: @campaign.template.email_template_path,
@@ -107,7 +107,10 @@ class PhishingFrenzyMailer < ActionMailer::Base
 
   def get_victim(email, campaign_id)
     victim = Victim.find_by(email_address: email, campaign_id: campaign_id)
-    victim = Victim.new(email_address: email, uid: '000000') unless victim
+    victim = Victim.new(email_address: email,
+                        uid: '000000',
+                        firstname: 'Firstname',
+                        lastname: 'Lastname') unless victim
 
     victim
   end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -17,7 +17,7 @@ class Campaign < ActiveRecord::Base
   has_many :smtp_communications
   has_many :baits, through: :blasts
   has_many :visits, through: :victims
-  
+
   accepts_nested_attributes_for :email_settings, allow_destroy: true
   accepts_nested_attributes_for :campaign_settings, allow_destroy: true
   accepts_nested_attributes_for :ssl, allow_destroy: true#, :reject_if => proc {|attributes| attributes['filename'].blank?}
@@ -42,8 +42,12 @@ class Campaign < ActiveRecord::Base
             :length => {:maximum => 255}
   validates :emails,
             :length => {:maximum => 60000}
+
+  validate :validate_email_addresses
+
   validates :scope, :numericality => {:greater_than_or_equal_to => 0},
             :length => {:maximum => 4}, :allow_nil => true
+
 
   def create_deps
     Ssl.functions.each do |function|
@@ -103,63 +107,53 @@ class Campaign < ActiveRecord::Base
 
   private
 
-  def parse_email_addresses
-    if not self.emails.blank?
-      entry = self.emails.split("\r\n")[0]
-      if entry.scan(/,/).count == 0
-        # email
-        parse_single_csv
-      elsif entry.scan(/,/).count == 1
-        # firstname, email
-        parse_double_csv
-      elsif entry.scan(/,/).count == 2
-        # firstname, lastname, email
-        parse_triple_csv
+  def validate_email_addresses
+    return if self.emails.blank?
+    count = self.emails.lines.first.split(',').count
+
+    if count > 3
+      errors.add(:emails, "Invalid input format '#{self.emails.lines.first}'")
+      return
+    end
+
+    self.emails.each_line do |l|
+      split = l.split(',').map(&:strip)
+      unless split.count == count
+        errors.add(:emails, "Email format is not consistent '#{l}'")
       end
-      
-      # clear the Campaigns.emails holder
-      self.update_attribute(:emails, " ")
+
+      unless split.last =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+        errors.add(:emails, "Invalid email format '#{split.last}'")
+      end
     end
   end
 
-  def parse_single_csv
-    victims = self.emails.split("\r\n")
-    victims.each do |v|
+  def parse_email_addresses
+    return if self.emails.blank?
+    count = self.emails.lines.first.split(',').count
+    return if count > 3
+
+    self.emails.each_line do |l|
+      split = l.split(',').map(&:strip)
+      next unless split.count == count
+
       victim = Victim.new
       victim.campaign_id = self.id
       victim.firstname = ""
       victim.lastname = ""
-      victim.email_address = v
+      victim.email_address = split.last
+      case count
+      when 2
+        victim.firstname = split.first
+      when 3
+        victim.firstname = split.first
+        victim.lastname = split[1]
+      end
       victim.save
     end
-  end
 
-  def parse_double_csv
-    victims = self.emails.split("\r\n")
-    victims.each do |v|
-      firstname = v.split(",")[0].strip
-      email = v.split(",")[1].strip
-      victim = Victim.new
-      victim.campaign_id = self.id
-      victim.firstname = firstname
-      victim.email_address = email
-      victim.save
-    end
-  end
-
-  def parse_triple_csv
-    victims = self.emails.split("\r\n")
-    victims.each do |v|
-      firstname = v.split(",")[0].strip
-      lastname = v.split(",")[1].strip
-      email = v.split(",")[2].strip
-      victim = Victim.new
-      victim.campaign_id = self.id
-      victim.firstname = firstname
-      victim.lastname = lastname
-      victim.email_address = email
-      victim.save
-    end
+    # clear the Campaigns.emails holder
+    self.update_attribute(:emails, " ")
   end
 
   def vhost_text(campaign, virtual_host_type)

--- a/app/models/victim.rb
+++ b/app/models/victim.rb
@@ -3,7 +3,7 @@ class Victim < ActiveRecord::Base
 	has_many :visits, dependent: :destroy
 
 	validates_format_of :email_address, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
-  validates_uniqueness_of :email_address, scope: :campaign_id
+	validates_uniqueness_of :email_address, scope: :campaign_id
 	before_create :default_values
 
 	attr_accessible :email_address, :uid, :campaign_id, :firstname, :lastname

--- a/app/models/victim.rb
+++ b/app/models/victim.rb
@@ -3,6 +3,7 @@ class Victim < ActiveRecord::Base
 	has_many :visits, dependent: :destroy
 
 	validates_format_of :email_address, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+  validates_uniqueness_of :email_address, scope: :campaign_id
 	before_create :default_values
 
 	attr_accessible :email_address, :uid, :campaign_id, :firstname, :lastname


### PR DESCRIPTION
* Fixes a bug introduced in fdd6b2e4a84fa07b347e4018579c061fe29c629c. @target no longer available for email generation
* Ensures Victim email addresses are unique for a campaign (Are there unintended consequences to this?)
* If generating a dummy victim the mailer now places in values for the names. 

Fixes #196 