### PR TITLE
Redirect reports to parent site

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -17,7 +17,7 @@ class ReportsController < ApplicationController
       victim = victims.first
       visit.victim_id = victim.id
       visit.browser = request.env["HTTP_USER_AGENT"]
-      visit.ip_address = request.env["REMOTE_ADDR"]
+      visit.ip_address = request.remote_ip
       visit.extra = "SOURCE: EMAIL"
       visit.save
     else

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -12,18 +12,18 @@ class ReportsController < ApplicationController
 
   def image
     victims = Victim.where(:uid => params[:uid])
-    unless victims.present?
-      render text: "No UID Found"
-      return
+    if victims.present?
+      visit = Visit.new
+      victim = victims.first
+      visit.victim_id = victim.id
+      visit.browser = request.env["HTTP_USER_AGENT"]
+      visit.ip_address = request.env["REMOTE_ADDR"]
+      visit.extra = "SOURCE: EMAIL"
+      visit.save
+    else
+      logger.info  "Image request for unknown UID: #{params[:uid]}"
     end
 
-    visit = Visit.new
-    victim = victims.first
-    visit.victim_id = victim.id
-    visit.browser = request.env["HTTP_USER_AGENT"]
-    visit.ip_address = request.env["REMOTE_ADDR"]
-    visit.extra = "SOURCE: EMAIL"
-    visit.save
     send_file File.join(Rails.root.to_s, "public", "tracking_pixel.png"), :type => 'image/png', :disposition => 'inline'
   end
 

--- a/app/mailers/phishing_frenzy_mailer.rb
+++ b/app/mailers/phishing_frenzy_mailer.rb
@@ -26,11 +26,11 @@ class PhishingFrenzyMailer < ActionMailer::Base
 
     if @campaign.campaign_settings.track_uniq_visitors?
       @url = "#{phishing_url}?uid=#{uid}"
-      @image_url = "#{GlobalSettings.first.site_url}/reports/image/#{uid}.png"
+      @image_url = "#{phishing_url}/reports/image/#{uid}.png"
     else
       @url = phishing_url
       # Don't know a default non-tracking image?
-      @image_url = "#{GlobalSettings.first.site_url}/reports/image/000000.png"
+      @image_url = "#{phishing_url}/reports/image/000000.png"
     end
 
     mail_opts =  {

--- a/app/models/global_settings.rb
+++ b/app/models/global_settings.rb
@@ -1,7 +1,18 @@
+class UriValidator < ActiveModel::Validator
+  require 'uri'
+
+  def validate(uri)
+    !!URI.parse(uri)
+  rescue URI::InvalidURIError
+    false
+  end
+end
+
 class GlobalSettings < ActiveRecord::Base
 
   attr_accessible :site_url, :command_apache_restart, :command_apache_vhosts, :command_apache_status, :sites_enabled_path, :smtp_timeout, :asynchronous, :bing_api, :beef_url, :reports_refresh
 
+  validates :site_url, uri: true
   validates :command_apache_restart, :presence => true, :length => {:maximum => 255}
   validates :command_apache_vhosts, :presence => true, :length => {:maximum => 255}
   validates :sites_enabled_path, :presence => true, :length => {:maximum => 255}
@@ -24,4 +35,6 @@ class GlobalSettings < ActiveRecord::Base
       vhosts_output.split("\n")[3..20]
     end
   end
+
 end
+

--- a/app/models/global_settings.rb
+++ b/app/models/global_settings.rb
@@ -1,13 +1,3 @@
-class UriValidator < ActiveModel::Validator
-  require 'uri'
-
-  def validate(uri)
-    !!URI.parse(uri)
-  rescue URI::InvalidURIError
-    false
-  end
-end
-
 class GlobalSettings < ActiveRecord::Base
 
   attr_accessible :site_url, :command_apache_restart, :command_apache_vhosts, :command_apache_status, :sites_enabled_path, :smtp_timeout, :asynchronous, :bing_api, :beef_url, :reports_refresh

--- a/app/validators/uri_validator.rb
+++ b/app/validators/uri_validator.rb
@@ -1,0 +1,9 @@
+class UriValidator < ActiveModel::Validator
+  require 'uri'
+
+  def validate(uri)
+    !!URI.parse(uri)
+  rescue URI::InvalidURIError
+    false
+  end
+end

--- a/app/views/campaigns/virtual_host.txt.erb
+++ b/app/views/campaigns/virtual_host.txt.erb
@@ -7,6 +7,12 @@
     CustomLog     <%= @approot %>/log/www-campaign-<%= @campaign_id %>-access.log combined
     ErrorLog      <%= @approot %>/log/www-campaign-<%= @campaign_id %>-error.log
 
+<% if GlobalSettings.first.site_url.downcase.include?('https://') %>
+    SSLProxyEngine On
+    SSLProxyCheckPeerCN off
+    SSLProxyCheckPeerExpire off
+<% end %>
+
     ProxyPass /reports/image <%= GlobalSettings.first.site_url %>/reports/image
     ProxyPassReverse /reports/image <%= GlobalSettings.first.site_url %>/reports/image
 

--- a/app/views/campaigns/virtual_host.txt.erb
+++ b/app/views/campaigns/virtual_host.txt.erb
@@ -6,5 +6,9 @@
     DirectoryIndex <%= @directory_index %>
     CustomLog     <%= @approot %>/log/www-campaign-<%= @campaign_id %>-access.log combined
     ErrorLog      <%= @approot %>/log/www-campaign-<%= @campaign_id %>-error.log
+
+    ProxyPass /reports/image <%= GlobalSettings.first.site_url %>/reports/image
+    ProxyPassReverse /reports/image <%= GlobalSettings.first.site_url %>/reports/image
+
 </VirtualHost>
 #<!--end <%= @campaign_id %>-->

--- a/app/views/campaigns/virtual_host_ssl.txt.erb
+++ b/app/views/campaigns/virtual_host_ssl.txt.erb
@@ -27,6 +27,12 @@
     CustomLog     <%= @approot %>/log/www-campaign-<%= @campaign_id %>-access.log combined
     ErrorLog      <%= @approot %>/log/www-campaign-<%= @campaign_id %>-error.log
 
+<% if GlobalSettings.first.site_url.downcase.include?('https://') %>
+    SSLProxyEngine On
+    SSLProxyCheckPeerCN off
+    SSLProxyCheckPeerExpire off
+<% end %>
+
     ProxyPass /reports/image <%= GlobalSettings.first.site_url %>/reports/image
     ProxyPassReverse /reports/image <%= GlobalSettings.first.site_url %>/reports/image
 </VirtualHost>

--- a/app/views/campaigns/virtual_host_ssl.txt.erb
+++ b/app/views/campaigns/virtual_host_ssl.txt.erb
@@ -2,6 +2,13 @@
     ServerName <%= @fqdn %>
     ServerAlias <%= @fqdn %>
     Redirect / https://<%= @fqdn %>/
+
+<% if GlobalSettings.first.site_url.downcase.include?('https://') %>
+    SSLProxyEngine On
+    SSLProxyCheckPeerCN off
+    SSLProxyCheckPeerExpire off
+<% end %>
+
     ProxyPass /reports/image <%= GlobalSettings.first.site_url %>/reports/image
     ProxyPassReverse /reports/image <%= GlobalSettings.first.site_url %>/reports/image
 </VirtualHost>

--- a/app/views/campaigns/virtual_host_ssl.txt.erb
+++ b/app/views/campaigns/virtual_host_ssl.txt.erb
@@ -2,6 +2,8 @@
     ServerName <%= @fqdn %>
     ServerAlias <%= @fqdn %>
     Redirect / https://<%= @fqdn %>/
+    ProxyPass /reports/image <%= GlobalSettings.first.site_url %>/reports/image
+    ProxyPassReverse /reports/image <%= GlobalSettings.first.site_url %>/reports/image
 </VirtualHost>
 
 #<!--start <%= @campaign_id %>-->
@@ -24,5 +26,8 @@
     DirectoryIndex <%= @directory_index %>
     CustomLog     <%= @approot %>/log/www-campaign-<%= @campaign_id %>-access.log combined
     ErrorLog      <%= @approot %>/log/www-campaign-<%= @campaign_id %>-error.log
+
+    ProxyPass /reports/image <%= GlobalSettings.first.site_url %>/reports/image
+    ProxyPassReverse /reports/image <%= GlobalSettings.first.site_url %>/reports/image
 </VirtualHost>
 #<!--end <%= @campaign_id %>-->


### PR DESCRIPTION
Resolves #197 

Adds a ProxyPass so the authenticated site will redirect /report/images/ to the underlying phishing frenzy site. 

Will need to enable proxy mods:

```
a2enmod proxy
a2enmod proxy_http
a2enmod proxy_connect
a2enmod ssl
service apache2 restart
```

Also makes sure the image UID always returns a blank image, instead of rendering text. We use an info log instead.

Additionally does some validation on SITE_URL
