### PR TITLE
Increase Launch performance

### DIFF
--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -52,8 +52,9 @@ class EmailController < ApplicationController
     blast = campaign.blasts.create(test: false)
     victims = Victim.where("campaign_id = ? and archive = ?", params[:id], false)
     begin
+      async = GlobalSettings.asynchronous?
       victims.each do |target|
-        if GlobalSettings.asynchronous?
+        if async
           MailWorker.perform_async(campaign.id, target.email_address, blast.id, PhishingFrenzyMailer::ACTIVE)
         else
           PhishingFrenzyMailer.phish(campaign.id, target.email_address, blast.id, PhishingFrenzyMailer::ACTIVE)

--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -51,25 +51,30 @@ class EmailController < ApplicationController
     campaign.update_attributes(active: true, email_sent: true)
     blast = campaign.blasts.create(test: false)
     victims = Victim.where("campaign_id = ? and archive = ?", params[:id], false)
-    begin
-      async = GlobalSettings.asynchronous?
-      victims.each do |target|
-        if async
+    async = GlobalSettings.asynchronous?
+    logger.info "Queueing #{victims.count} emails for background delivery"
+    victims.each do |target|
+      if async
+        begin
           MailWorker.perform_async(campaign.id, target.email_address, blast.id, PhishingFrenzyMailer::ACTIVE)
-        else
-          PhishingFrenzyMailer.phish(campaign.id, target.email_address, blast.id, PhishingFrenzyMailer::ACTIVE)
+        rescue Redis::CannotConnectError
+          flash[:error] = "Sidekiq cannot connect to Redis. Emails were not queued."
+          break
         end
-        target.update_attribute(:sent, true)
+      else
+        begin
+          PhishingFrenzyMailer.phish(campaign.id, target.email_address, blast.id, PhishingFrenzyMailer::ACTIVE)
+        rescue ::NoMethodError
+          flash[:error] = "Template is missing an email file, upload and create new email"
+          break
+        rescue Exception => e
+          flash[:error] = "Generic Template Issue: #{e}"
+          break
+        end
       end
-      flash[:notice] = "Campaign blast launched"
-    rescue Redis::CannotConnectError => e
-      flash[:error] = "Sidekiq cannot connect to Redis. Emails were not queued."
-    rescue::NoMethodError
-      flash[:error] = "Template is missing an email file, upload and create new email"
-    rescue => e
-      flash[:error] = "Generic Template Issue: #{e}"
     end
 
+    flash[:notice] = "Campaign blast launched"
     redirect_to :back
   end
 

--- a/app/controllers/email_controller.rb
+++ b/app/controllers/email_controller.rb
@@ -52,7 +52,8 @@ class EmailController < ApplicationController
     blast = campaign.blasts.create(test: false)
     victims = Victim.where("campaign_id = ? and archive = ?", params[:id], false)
     async = GlobalSettings.asynchronous?
-    logger.info "Queueing #{victims.count} emails for background delivery"
+
+    logger.info "Queueing #{victims.count} emails for background delivery" if async
     victims.each do |target|
       if async
         begin

--- a/app/mailers/phishing_frenzy_mailer.rb
+++ b/app/mailers/phishing_frenzy_mailer.rb
@@ -60,16 +60,19 @@ class PhishingFrenzyMailer < ActionMailer::Base
       raise RuntimeError, 'Unknown mailer action'
     end
 
-    cast(blast, bait)
+    sent = cast(blast, bait)
+    @target.update_attribute(:sent, true) if sent
   end
 
   def cast(blast, bait)
+    sent = false
     # log smtp communication
     response = nil
     error = nil
     begin
       sleep(@campaign.campaign_settings.smtp_delay)
       response = bait.deliver!
+      sent = true
     rescue => e
       error = e
     end
@@ -85,6 +88,8 @@ class PhishingFrenzyMailer < ActionMailer::Base
 
     # commit changes
     smtp.save
+
+    sent
   end
 
   def campaign_smtp_settings


### PR DESCRIPTION
Remove unnecessary DB lookup in loop. Halves the time to perform the action with a single line change.

Move the `sent` attribute update to the `PhishingFrenzyMailer` to remove all the database updates from the loop. Also moved the exception handling to wrap more precisely where they will be raised.

We can keep the DB updates here and wrap the loop in a transaction to prevent `x` update calls to the database and still get it down to about 4s. However if something fails midway we will lose our previous updates...

The result of these changes drops 5000 email sends from 18s to 3s in my development environment.

N.b. this only applies to background mailing. Foreground mailing will remain slow as all the db queries are  still performed.