### PR TITLE
update apache2 status output for kali 2 support

### DIFF
--- a/app/models/system_monitor.rb
+++ b/app/models/system_monitor.rb
@@ -3,7 +3,7 @@ class SystemMonitor
   # determine if apache is running
   def self.apache
     apache_output = GlobalSettings.apache_status
-    apache_output =~ /pid/
+    apache_output =~ /pid|(running)/
   end
 
   # determine if any VHOST are configured


### PR DESCRIPTION
apache2 status output on kali 2 does not contain pid. Which mean that the system status  is unable to detect if apache is running or not. The Apache icon is gray even if the daemon is running.

So I suggest changing the code from /pid/ to /pid|(running)/. This fixes  the problem, so the apache symbol is green in the status monitor on kali 2. It should work on linux installations where the apache2 status output contains pid (I tested this by adding "echo pid" to the apache2 status command).