### PR TITLE
change line number due to output change in kali2

### DIFF
--- a/app/models/global_settings.rb
+++ b/app/models/global_settings.rb
@@ -21,7 +21,7 @@ class GlobalSettings < ActiveRecord::Base
     if vhosts_output.blank?
       []
     else
-      vhosts_output.split("\n")[3..20]
+      vhosts_output.split("\n")[1..20]
     end
   end
 end


### PR DESCRIPTION
apache2ctl -S output is different in kali 2. I use "apache2ctl -D DUMP_VHOSTS", and changed the number in the split code.

A message will appear at the top of the output in this command if the ServerName is not correctly configured in apache2.