### PR TITLE
Dont check CSRF on PHP callbacks

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,6 @@
 class ReportsController < ApplicationController
   skip_before_filter :authenticate_admin!, only: [ :results, :image ]
+  protect_from_forgery except: [ :results, :image ]
 
   def index
     list


### PR DESCRIPTION
Phishing frenzy complains about CSRF checks on some of the PHP callbacks.

```
Processing by ReportsController#results as HTML
  Parameters: {"uid"=>"AZHCFKJK", "browser_info"=>"Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36", "ip_address"=>"x", "extra"=>"user:test password:test"}
Can't verify CSRF token authenticity
```
