### PR TITLE
Allow PHP parameters in phishing URL

### DIFF
--- a/app/mailers/phishing_frenzy_mailer.rb
+++ b/app/mailers/phishing_frenzy_mailer.rb
@@ -33,7 +33,11 @@ class PhishingFrenzyMailer < ActionMailer::Base
     uid = @target.uid.to_s
 
     if @campaign.campaign_settings.track_uniq_visitors?
-      @url = "#{phishing_url}?uid=#{uid}"
+      if not phishing_url.include? "/?"
+        @url = "#{phishing_url}?uid=#{uid}"
+      else
+        @url = "#{phishing_url}&uid=#{uid}"
+      end
       @image_url = "#{phishing_url}/reports/image/#{uid}.png"
     else
       @url = phishing_url


### PR DESCRIPTION
In playing around with a sample campaign, I noticed that the UID is appended directly to the URL operating on the assumption that the URL is formatted as "hxxp://site.url.com/" which makes it not possible to include your own PHP parameters in the URL; if you do, the actual URL becomes "hxxp://site.url.com/?myparameter=1?uid=00000" instead of "hxxp://site.url.com/?myparameter=1&uid=00000"

This PR allows you to include your own parameters to be passed to the phishing page. For example I use a parameter on some pages that will imbed a meterpreter HTA file. The way it's set up now I either have to modify the template or manually modify the landing page to set the msf variable, instead of just being able to set it by doing something like "hxxp://site.url.com/?msf=1" to trigger it during the campaign setup.